### PR TITLE
Update TwilioClient to typescript and and sendSms function

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -22,4 +22,12 @@ module.exports = {
     'import/extensions': 'off',
     'prettier/prettier': ['error'],
   },
+  overrides: [
+    {
+      files: ["*.js"],
+      rules: {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
+  ]
 };

--- a/backend/src/services/AllowlistEntry.js
+++ b/backend/src/services/AllowlistEntry.js
@@ -1,3 +1,4 @@
+const { sendSms } = require('./TwilioClient');
 const { UserTypes } = require('../models');
 const { sanitizeDbErrors } = require('./lib');
 
@@ -15,13 +16,15 @@ function AllowlistEntryService(AllowlistEntryModel) {
   }
 
   async function createAllowlistEntry({ phoneNumber, destinationCountry }) {
-    return sanitizeDbErrors(() =>
+    const dbResponse = await sanitizeDbErrors(() =>
       AllowlistEntryModel.create({
         role: UserTypes.USER,
         phoneNumber,
         destinationCountry,
       })
     );
+    await sendSms('Welcome to Call Home. Your account is ready!', phoneNumber);
+    return dbResponse;
   }
 
   async function deleteAllowlistEntry(id) {

--- a/backend/src/services/AllowlistEntry.js
+++ b/backend/src/services/AllowlistEntry.js
@@ -1,4 +1,4 @@
-const { sendSms } = require('./TwilioClient');
+// const { sendSms } = require('./TwilioClient');
 const { UserTypes } = require('../models');
 const { sanitizeDbErrors } = require('./lib');
 
@@ -23,7 +23,7 @@ function AllowlistEntryService(AllowlistEntryModel) {
         destinationCountry,
       })
     );
-    await sendSms('Welcome to Call Home. Your account is ready!', phoneNumber);
+    // await sendSms('Welcome to Call Home. Your account is ready!', phoneNumber);
     return dbResponse;
   }
 

--- a/backend/src/services/TwilioClient.js
+++ b/backend/src/services/TwilioClient.js
@@ -5,6 +5,7 @@ const {
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
   TWILIO_PHONE_NUMBER,
+  TWILIO_SMS_PHONE_NUMBER,
 } = process.env;
 const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
@@ -26,8 +27,17 @@ async function listOutgoingCalls(options = { limit: 20 }) {
   });
 }
 
+async function sendSms(body, to) {
+  return twilioClient.messages.create({
+    body,
+    from: TWILIO_SMS_PHONE_NUMBER,
+    to,
+  });
+}
+
 module.exports = {
   getCall,
   listOutgoingCalls,
   getCallsByIncomingSid,
+  sendSms,
 };

--- a/backend/src/services/TwilioClient.ts
+++ b/backend/src/services/TwilioClient.ts
@@ -1,20 +1,29 @@
 // TODO move the API clients somewhere else
-const twilio = require('twilio');
+import twilio from 'twilio';
 
 const {
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
-  TWILIO_PHONE_NUMBER,
+  TWILIO_CALL_PHONE_NUMBER,
   TWILIO_SMS_PHONE_NUMBER,
 } = process.env;
+
 const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
-async function getCall(twilioCallSid) {
+async function getCall(twilioCallSid: string) {
   return twilioClient.calls(twilioCallSid).fetch();
 }
 
-async function getCallsByIncomingSid(twilioCallSid) {
+async function getCallsByIncomingSid(twilioCallSid: string) {
   return twilioClient.calls.list({ parentCallSid: twilioCallSid });
+}
+
+async function sendSms(toPhoneNumber: string, body: string) {
+  return twilioClient.messages.create({
+    body,
+    to: toPhoneNumber,
+    from: TWILIO_SMS_PHONE_NUMBER,
+  });
 }
 
 // It's important to specify this is outgoing because TwiML from the browser is treated as an 'incoming call'
@@ -22,22 +31,10 @@ async function getCallsByIncomingSid(twilioCallSid) {
 // OMG KILL ME
 async function listOutgoingCalls(options = { limit: 20 }) {
   return twilioClient.calls.list({
-    from: TWILIO_PHONE_NUMBER,
+    from: TWILIO_CALL_PHONE_NUMBER,
     ...options,
   });
 }
 
-async function sendSms(body, to) {
-  return twilioClient.messages.create({
-    body,
-    from: TWILIO_SMS_PHONE_NUMBER,
-    to,
-  });
-}
-
-module.exports = {
-  getCall,
-  listOutgoingCalls,
-  getCallsByIncomingSid,
-  sendSms,
-};
+export { getCall, listOutgoingCalls, getCallsByIncomingSid, sendSms };
+export default { getCall, listOutgoingCalls, getCallsByIncomingSid, sendSms };

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -3,13 +3,13 @@ import * as models from '../models';
 import Call from './Call';
 import PeriodicCredit from './PeriodicCredit';
 import TwilioCall from './TwilioCall';
+import TwilioClient from './TwilioClient';
 import Transaction from './Transaction';
 import Wallet from './Wallet';
 import User from './User';
 import * as Feature from './Feature';
 import Contact = require('./Contact');
 import AllowlistEntry = require('./AllowlistEntry');
-import TwilioClient = require('./TwilioClient');
 import Auth0 = require('./Auth0');
 import PasswordlessRequest = require('./PasswordlessRequest');
 


### PR DESCRIPTION
new env variable for SMS `TWILIO_SMS_PHONE_NUMBER` is required. This is the Twilio phone number used by auth0.

- Probably needs a better message template (not applicable. usage of sendSms to be deferred to another PR)

Regarding rate limiting for bulk adding of numbers, https://support.twilio.com/hc/en-us/articles/115002943027-Understanding-Twilio-Rate-Limits-and-Message-Queues

In summary: We can send Twilio many SMS requests that get queued (queue size 144,000), but they will get sent at max 10 messages/sec