### PR TITLE
Adding redemption status and user_createdAt timestamp

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -49,6 +49,9 @@ class User extends Model<User> {
   })
   @Column
   destinationCountry: string;
+
+  @Column
+  createdAt: string;
 }
 
 export default User;

--- a/frontend/src/scenes/AdminPage/RedeemableCodeTabContent.tsx
+++ b/frontend/src/scenes/AdminPage/RedeemableCodeTabContent.tsx
@@ -92,6 +92,7 @@ export default function RedeemableCodeTabContent() {
             <TableRow>
               <TableCell>Code</TableCell>
               <TableCell>QR</TableCell>
+              <TableCell>Status</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -106,6 +107,7 @@ export default function RedeemableCodeTabContent() {
                     <CropFreeIcon />
                   </IconButton>
                 </TableCell>
+                <TableCell>{redeemableCode.redemptionLimit}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/frontend/src/scenes/AdminPage/UserTabContent.tsx
+++ b/frontend/src/scenes/AdminPage/UserTabContent.tsx
@@ -14,6 +14,7 @@ interface UserGridRow {
   phoneNumber: string | null;
   destinationCountry: string;
   callTime: string | null;
+  createdAt: string | null;
   hasAdminGrantedValidation: boolean;
 }
 
@@ -72,9 +73,12 @@ export default function UserTabContent() {
     phoneNumber: user.phoneNumber,
     destinationCountry: user.destinationCountry,
     callTime:
-      user.callTime === undefined || user.callTime === null
+      user.callTime == null
         ? ''
         : formatSecondsWithHours(user.callTime),
+    createdAt: user.createdAt == null
+        ? ''
+        : user.createdAt,
     hasAdminGrantedValidation: user.verificationState.adminGranted,
   }));
 

--- a/shared/types/User.ts
+++ b/shared/types/User.ts
@@ -18,4 +18,5 @@ export interface UserWalletResponse {
 
   phoneNumber: string | null;
   callTime: number | null;
+  createdAt: string | null;
 }


### PR DESCRIPTION
- Added timestamp for when a user is signed up. This is for us to sort by the date they signed up with us for a quick count on how many we managed to onboard (without accessing the DB)

- Added a status for the redemption promo codes. Technically promo codes should only show if they are "redeemable" but this can be easily confused. Added for clarity that the redemption count is at 1.