### PR TITLE
Add footer to verification scenes

### DIFF
--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import ReportIssueDialog from 'components/shared/ReportIssueDialog';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+import FeedbackIcon from '@material-ui/icons/Feedback';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import { useUserService } from 'contexts';
+import { Locale } from 'scenes/types';
+
+const STRINGS = {
+  en: {
+    CONTACTS_LOGOUT_LABEL: 'Logout',
+    CONTACTS_REPORT_PROBLEM_LABEL: 'Report Problem',
+  },
+  bn: {
+    CONTACTS_LOGOUT_LABEL: 'প্রস্থান', // Google translate
+    CONTACTS_REPORT_PROBLEM_LABEL: 'সমস্যা রিপোর্ট করুন',
+  },
+};
+
+interface FooterProps {
+  locale: Locale;
+}
+
+export default function Footer({ locale }: FooterProps) {
+  const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = useState(false);
+  const openFeedbackDialog = () => setIsFeedbackDialogOpen(true);
+  const logout = async () => {
+    (window as any).location = '/oauth/logout';
+  };
+  const [userState] = useUserService();
+  const { me: user } = userState || {};
+  const ActionLink = withStyles((theme) => ({
+    root: {
+      cursor: 'pointer',
+      display: 'flex',
+      color: (theme as any).palette.primary[900],
+    },
+  }))(Typography);
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginTop: '12px',
+        padding: '8px',
+      }}
+    >
+      <ActionLink variant="body1" role="button" onClick={openFeedbackDialog}>
+        <FeedbackIcon />
+        {STRINGS[locale].CONTACTS_REPORT_PROBLEM_LABEL}
+      </ActionLink>
+      <ActionLink variant="body1" role="button" onClick={logout}>
+        <ExitToAppIcon style={{ transform: 'rotate(180deg)' }} />
+        {STRINGS[locale].CONTACTS_LOGOUT_LABEL}
+      </ActionLink>
+      <ReportIssueDialog
+        user={user}
+        onClose={() => setIsFeedbackDialogOpen(false)}
+        open={isFeedbackDialogOpen}
+        locale={locale}
+      />
+    </div>
+  );
+}

--- a/frontend/src/scenes/Home/ContactsPage.tsx
+++ b/frontend/src/scenes/Home/ContactsPage.tsx
@@ -38,6 +38,7 @@ import PATHS from 'scenes/paths';
 import './ContactsPage.css';
 import { Locale, SceneProps } from 'scenes/types';
 import { RoundedProgressBar } from 'components/shared/RoundedProgressBar';
+import Footer from 'components/shared/Footer';
 
 const COUNTRIES = {
   en: {
@@ -778,25 +779,11 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
           justifyContent: 'space-between',
         }}
       >
-        <ActionLink variant="body1" role="button" onClick={openFeedbackDialog}>
-          <FeedbackIcon />
-          {STRINGS[locale].CONTACTS_REPORT_PROBLEM_LABEL}
-        </ActionLink>
-        <ActionLink variant="body1" role="button" onClick={logout}>
-          <ExitToAppIcon style={{ transform: 'rotate(180deg)' }} />
-          {STRINGS[locale].CONTACTS_LOGOUT_LABEL}
-        </ActionLink>
         <AddContactDialog
           onClose={() => {
             history.replace('');
           }}
           open={isAddDialogOpen}
-          locale={locale}
-        />
-        <ReportIssueDialog
-          user={user}
-          onClose={() => setIsFeedbackDialogOpen(false)}
-          open={isFeedbackDialogOpen}
           locale={locale}
         />
         {contactToEdit ? (
@@ -808,6 +795,7 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
           />
         ) : null}
       </div>
+      <Footer locale={locale} />
     </Container>
   );
 }

--- a/frontend/src/scenes/Verify/VerifyPhoneNumber.tsx
+++ b/frontend/src/scenes/Verify/VerifyPhoneNumber.tsx
@@ -6,6 +6,7 @@ import { useUserService } from 'contexts';
 import { PrimaryButton } from 'components/shared/RoundedButton';
 import PhoneNumberMasks from 'components/shared/PhoneNumberMask';
 import { SceneProps } from 'scenes/types';
+import Footer from 'components/shared/Footer';
 
 const Container: React.FunctionComponent<any> = ContainerWrong;
 const TextField: React.FunctionComponent<any> = TextFieldWrong;
@@ -93,6 +94,7 @@ export default function VerifyPhoneNumber({ locale }: SceneProps) {
           </PrimaryButton>
         </div>
       </form>
+      <Footer locale={locale} />
     </Container>
   );
 }

--- a/frontend/src/scenes/Verify/VerifyPhoneNumberCode.tsx
+++ b/frontend/src/scenes/Verify/VerifyPhoneNumberCode.tsx
@@ -6,6 +6,7 @@ import { useUserService } from 'contexts';
 import RoundedButton, { PrimaryButton } from 'components/shared/RoundedButton';
 import { beginPhoneNumberValidation, login } from 'services/Auth';
 import { SceneProps } from 'scenes/types';
+import Footer from 'components/shared/Footer';
 
 interface VerifyPhoneNumberCodeProps extends SceneProps {
   phoneNumber: string;
@@ -188,5 +189,10 @@ export default function VerificationPhoneNumberCode({
       </form>
     );
   }
-  return <Container>{content}</Container>;
+  return (
+    <Container>
+      {content}
+      <Footer locale={locale} />
+    </Container>
+  );
 }

--- a/frontend/src/scenes/Verify/VerifyWorkpass.tsx
+++ b/frontend/src/scenes/Verify/VerifyWorkpass.tsx
@@ -9,6 +9,7 @@ import { PrimaryButton } from 'components/shared/RoundedButton';
 import { validateWorkpass } from 'services/WorkpassValidation';
 import { Locale, SceneProps } from 'scenes/types';
 import './VerifyWorkpass.css';
+import Footer from 'components/shared/Footer';
 
 const EN_STRINGS = {
   VERIFY_WORKPASS_TITLE: 'Enter your Work Pass serial number',
@@ -190,6 +191,7 @@ function VerifyWorkpassPresenter({
           {STRINGS[locale].NEXT}
         </PrimaryButton>
       </form>
+      <Footer locale={locale} />
     </Container>
   );
 }


### PR DESCRIPTION
Created a reusable footer component for all verification scenes, comprises of report issue button and logout button so that users can now logout on every scene.
<img src= "https://user-images.githubusercontent.com/57614749/109779235-b583d880-7c40-11eb-9aff-9fadf892caec.jpeg"  width="250px">
<img src= "https://user-images.githubusercontent.com/57614749/109779246-b7e63280-7c40-11eb-83eb-66b2c03e5e5b.jpeg"  width="250px">
<img src= "https://user-images.githubusercontent.com/57614749/109779248-b87ec900-7c40-11eb-8e46-a853368f527d.jpeg"  width="250px">
