### PR TITLE
fixed long name formatting

### DIFF
--- a/frontend/src/scenes/Home/ContactsPage.tsx
+++ b/frontend/src/scenes/Home/ContactsPage.tsx
@@ -662,10 +662,11 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
       >
         <div
           style={{
-            overflowY: 'scroll',
             width: '100%',
-            // 20em to accomodate logout and add contact button
-            maxHeight: 'calc(var(--viewport-height) - 20rem)',
+            // 24rem to accomodate logout and add contact button
+            maxHeight: 'calc(var(--viewport-height) - 24rem)',
+            overflow: 'auto',
+            minHeight: '4em',
           }}
         >
           <List
@@ -688,8 +689,9 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
                     alignItems: 'center',
                     justifyContent: 'space-between',
                     width: '100%',
-                    height: '4em',
+                    minHeight: '4em',
                     padding: '4px 8px',
+                    borderRadius: '8px',
                   }}
                   variant="outlined"
                 >
@@ -717,7 +719,12 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
                         flex: '1 0',
                       }}
                     >
-                      <Typography variant="body1">{contact.name}</Typography>
+                      <Typography
+                        variant="body1"
+                        style={{ overflowWrap: 'anywhere' }}
+                      >
+                        {contact.name}
+                      </Typography>
                       <div style={{ display: 'flex' }}>
                         <Typography
                           style={{
@@ -754,6 +761,7 @@ export default function ContactsPage({ locale, routePath }: SceneProps) {
             width: '100%',
             height: '4em',
             marginTop: '1em',
+            borderRadius: '8px',
           }}
           variant="outlined"
           onClick={() => {


### PR DESCRIPTION
remake of PR #33 

Fixed formatting of long names in contact list and rounded contact box to match the MVP in figma.
![contacts_before_after](https://user-images.githubusercontent.com/57614749/102017111-d3f3d980-3d9f-11eb-8f98-322343d523b1.png)

<h1>before: </h1>
<img src ="https://user-images.githubusercontent.com/57614749/102175067-c6db0580-3ed9-11eb-9e0a-00354d0cd7ab.png" width=50% height=50%>
<h1>after: </h1>
<img src ="https://user-images.githubusercontent.com/57614749/102175095-d0646d80-3ed9-11eb-9454-020c1922b709.png" width=50% height=50%>