### PR TITLE
Periodically invalidate PhoneNumberValidations

### DIFF
--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -1,13 +1,15 @@
 import { logger } from '../config';
-import { Feature, TwilioCall } from '../services';
+import { Feature, PhoneNumberValidation, TwilioCall } from '../services';
 import refreshConnectedCalls from './refreshConnectedCalls';
 import refreshNoPriceCalls from './refreshNoPriceCalls';
 import refreshJoinedCalls from './refreshJoinedCalls';
+import refreshPhoneNumberStatus from './refreshPhoneNumberStatus';
 
 if (!Feature.shouldDisablePeriodicJobs()) {
   logger.info('Initializing jobs');
   refreshConnectedCalls(TwilioCall);
   refreshNoPriceCalls(TwilioCall);
+  refreshPhoneNumberStatus(PhoneNumberValidation);
   refreshJoinedCalls();
 } else {
   logger.info('Periodic jobs disabled');

--- a/backend/src/jobs/refreshPhoneNumberStatus.ts
+++ b/backend/src/jobs/refreshPhoneNumberStatus.ts
@@ -1,0 +1,23 @@
+import { logger } from '../config';
+import type { PhoneNumberValidation } from '../services';
+
+// Hourly
+const JOB_INTERVAL_MILLIS = 60 * 60 * 1000;
+
+function refreshPhoneNumberStatus(
+  phoneNumberValidationService: typeof PhoneNumberValidation
+): void {
+  async function job(): Promise<void> {
+    try {
+      logger.info('refreshPhoneNumberStatus==========');
+      await phoneNumberValidationService.invalidateExpiredEntries();
+    } catch (error) {
+      logger.error(error);
+    } finally {
+      setTimeout(job, JOB_INTERVAL_MILLIS);
+    }
+  }
+  job();
+}
+
+export default refreshPhoneNumberStatus;


### PR DESCRIPTION
This adds an expiry to PhoneNumberValidations, which means that users will have
to periodically revalidate their phone numbers. This helps ensure that our users
are indeed based in Singapore.